### PR TITLE
Update network_info.dart

### DIFF
--- a/lib/core/network/network_info.dart
+++ b/lib/core/network/network_info.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 
 abstract class NetworkInfo {
-  Future<bool> get isConnected;
+  Future<bool>? get isConnected;
 }
 
 class NetworkInfoImpl implements NetworkInfo {


### PR DESCRIPTION
test ''should check if the device is online'' going to fails type 'Null' is not a subtype of type 'Future<bool>' on
when(mockNetworkInfo.isConnected).thenAnswer((_) async => true);